### PR TITLE
Using six for checking if variables is string or nor

### DIFF
--- a/python/cdo.py
+++ b/python/cdo.py
@@ -3,6 +3,7 @@ import os,re,subprocess,tempfile,random,sys
 from pkg_resources import parse_version
 from io import StringIO
 import logging as pyLog
+import six
 try:
     from string import strip
 except ImportError:
@@ -42,7 +43,7 @@ def setupLogging(logFile):
     logger = pyLog.getLogger(__name__)
     logger.setLevel(pyLog.INFO)
 
-    if isinstance(logFile,str):
+    if isinstance(logFile, six.string_types):
         handler = pyLog.FileHandler(logFile)
     else:
         handler = pyLog.StreamHandler(stream=logFile)
@@ -128,12 +129,6 @@ class Cdo(object):
     res.extend(self.operators)
     return res
 
-  def isString(self,myString):
-      if (2 == sys.version_info[0]):
-          return isinstance(myString,basestring)
-      else:
-          return isinstance(myString,str)
-
   def call(self,cmd):
     if self.logging and '-h' != cmd[1]:
       self.logger.info(u' '.join(cmd))
@@ -206,7 +201,7 @@ class Cdo(object):
       cmd.append(','.join(operator))
       #4. input files or operators
       if 'input' in kwargs:
-        if self.isString(kwargs["input"]):
+        if isinstance(kwargs["input"], six.string_types):
             cmd.append(kwargs["input"])
         else:
             #we assume it's either a list, a tuple or any iterable.
@@ -354,7 +349,7 @@ class Cdo(object):
       self.setReturnArray(False)
 
   def collectLogs(self):
-      if isinstance(self.logFile,str):
+      if isinstance(self.logFile, six.string_types):
           content = []
           with open(self.logFile,'r') as f:
               content.append(f.read())

--- a/python/setup.py
+++ b/python/setup.py
@@ -15,4 +15,5 @@ setup (name   = 'cdo',
         "Operating System :: POSIX",
         "Programming Language :: Python",
     ],
+  install_requires=['six'],
   )

--- a/python/test/test_cdo.py
+++ b/python/test/test_cdo.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import unittest,os,tempfile,sys,glob,subprocess,multiprocessing
 from stat import *
-from testcdo import *
+from cdo import *
 import numpy as np
 from matplotlib import pylab as pl
 
@@ -523,6 +523,14 @@ class CdoTest(unittest.TestCase):
         cmd = '-fldmean -mul -random,r20x20 -topo,r20x20'
         print('# logging with a real file')
         cdo = Cdo(cdfMod=CDF_MOD,logging = True,logFile='foo.log')
+        cdo.topo()
+        cdo.temp()
+        cdo.sinfov(input=cmd)
+        cdo.showLog()
+
+        cmd = '-fldmean -mul -random,r20x20 -topo,r20x20'
+        print('# logging with a real file, passed as unicode string')
+        cdo = Cdo(cdfMod=CDF_MOD, logging=True, logFile=u'foo.log')
         cdo.topo()
         cdo.temp()
         cdo.sinfov(input=cmd)


### PR DESCRIPTION
Instead of using custom code, now we are making use of the six package to maintain compatibility with Python 2.x and 3.x when checking if a variable is a string. I have also modified all checks so all of them are doing it correctly now.

Please note that one of them is outside the class and couldn't use the previous method