### PR TITLE
Be more pythonic

### DIFF
--- a/python/cdo.py
+++ b/python/cdo.py
@@ -668,7 +668,7 @@ class Cdo(object):
 
     return delta_levels
 
-  def read(self, output=None):
+  def run(self, output=None):
     if output:
       return self(output=output, compute=True)
     else:
@@ -677,7 +677,7 @@ class Cdo(object):
   def readCdf(self, iFile=None):
     """Return a cdf handle created by the available cdf library"""
     if iFile is None:
-      iFile = self.read()
+      iFile = self.run()
     if self.hasNetcdf:
       fileObj = self.cdf(iFile, mode='r')
       return fileObj
@@ -688,7 +688,7 @@ class Cdo(object):
   def readArray(self, iFile=None, varname=None):
     """Direcly return a numpy array for a given variable name"""
     if iFile is None:
-      iFile = self.read()
+      iFile = self.run()
     if varname is None:
       raise ValueError("A varname needs to be specified!")
     filehandle = self.readCdf(iFile)
@@ -703,7 +703,7 @@ class Cdo(object):
   def readMaArray(self, iFile=None, varname=None):# {{{
     """Create a masked array based on cdf's FillValue"""
     if iFile is None:
-      iFile = self.read()
+      iFile = self.run()
     if varname is None:
       raise ValueError("A varname needs to be specified!")
     fileObj = self.readCdf(iFile)
@@ -725,7 +725,7 @@ class Cdo(object):
 
   def readXArray(self, ifile=None, varname=None):
     if ifile is None:
-      ifile = self.read()
+      ifile = self.run()
     if varname is None:
       raise ValueError("A varname needs to be specified!")
     if not self.hasXarray:
@@ -741,7 +741,7 @@ class Cdo(object):
 
   def readXDataset(self, ifile=None):
     if ifile is None:
-      ifile = self.read()
+      ifile = self.run()
     if not self.hasXarray:
       print("Could not load XArray")
       six.raise_from(ImportError,None)

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -52,15 +52,18 @@ def auto_doc(tool, path2cdo):
     c = cdo.Cdo()
     help(c.sinfov)"""
   def desc(func):
+    func.__doc__ = operator_doc(tool, path2cdo)
+    return func
+  return desc
+#}}}
+
+def operator_doc(tool, path2cdo):
     proc = subprocess.Popen('%s -h %s ' % (path2cdo, tool),
                             shell=True,
                             stderr=subprocess.PIPE,
                             stdout=subprocess.PIPE)
     retvals = proc.communicate()
-    func.__doc__ = retvals[0].decode("utf-8")
-    return func
-  return desc
-#}}}
+    return retvals[0].decode("utf-8")
 
 # some helper functions without side effects {{{
 def getCdoVersion(path2cdo, verbose=False):
@@ -124,6 +127,8 @@ class Cdo(object):
   splitday splitgrid splithour splitlevel splitmon splitname splitparam splitrec \
   splitseas splitsel splittabnum splitvar splityear splityearmon splitzaxis'.split() #}}}
 
+  name = ''
+
   def __init__(self,
                cdo='cdo',
                returnNoneOnError=False,
@@ -132,12 +137,17 @@ class Cdo(object):
                debug=False,
                tempdir=tempfile.gettempdir(),
                logging=False,
-               logFile=StringIO()):
+               logFile=StringIO(),
+               cmd=[],
+               options=[]):
 
     if 'CDO' in os.environ:
       self.CDO = os.environ['CDO']
     else:
       self.CDO = cdo
+
+    self._cmd = cmd
+    self._options = options
 
     self.operators         = self.__getOperators()
     self.noOutputOperators = [op for op in self.operators.keys() if 0 == self.operators[op]]
@@ -171,6 +181,21 @@ class Cdo(object):
     # other left-overs can only be handled afterwards
     # might be good to use the tempdir keyword to ease this, but deletion can
     # be triggered using cleanTempDir() }}}
+
+  def __get__(self, instance, owner):
+    if instance is None:
+      return self
+    return self.__class__(
+        instance.CDO,
+        instance.returnNoneOnError,
+        instance.forceOutput,
+        instance.env,
+        instance.debug,
+        instance.tempStore.dir,
+        instance.logging,
+        instance.logFile,
+        instance._cmd + ['-' + self.name],
+        instance._options)
 
   # from 1.9.6 onwards CDO returns 1 of diff* finds a difference
   def __exit_success(self,operatorName):
@@ -298,7 +323,7 @@ class Cdo(object):
       return False  # }}}
 
   # {{{ attempt to load optional libraries: netcdf-IO + XArray
-  # numpy is a dependency of both, so no need to check that 
+  # numpy is a dependency of both, so no need to check that
   def __loadOptionalLibs(self):
     try:
       import xarray
@@ -316,158 +341,189 @@ class Cdo(object):
     except:
       print("-->> Could not load netCDF4! <<--") #}}}
 
-  def __getattr__(self, method_name):  # main method-call handling for Cdo-objects {{{
+  def infile(self, *infiles):
+    for infile in infiles:
+      if isinstance(infile, six.string_types):
+        self._cmd.append(infile)
+      elif self.hasXarray:
+        import xarray #<<-- python2 workaround
+        if (type(infile) == xarray.core.dataset.Dataset):
+          # create a temp nc file from input data
+          tmpfile = self.tempStore.newFile()
+          infile.to_netcdf(tmpfile)
+          self._cmd.append(tmpfile)
+    return self
 
-    @auto_doc(method_name, self.CDO)
-    def get(self, *args, **kwargs):
-      operatorPrintsOut = method_name in self.noOutputOperators
+  def add_option(self, *options):
+    self._options = self._options + list(options)
+    return self
 
-      self.envByCall = {}
+  def __call__(self, *args, **kwargs):
+    try:
+      method_name = self._cmd[0][1:].split(',')[0]
+    except IndexError:
+      method_name = ''
+    operatorPrintsOut = method_name in self.noOutputOperators
 
-      # Build the cdo command
-      # 0. the cdo command itself
-      cmd = [self.CDO]
+    self.envByCall = {}
 
-      # 1. OVERWRITE EXISTING FILES
-      cmd.append('-O')
+    # Build the cdo command
+    # 0. the cdo command itself
+    cmd = [self.CDO]
 
-      # 2. set the options
-      # switch to netcdf output in case of numpy/xarray usage
-      if (   None != kwargs.get('returnArray')
-          or None != kwargs.get('returnMaArray')
-          or None != kwargs.get('returnXArray')
-          or None != kwargs.get('returnXDataset')
-          or None != kwargs.get('returnCdf')):
-        cmd.append('-f nc')
-      if 'options' in kwargs:
-        cmd += kwargs['options'].split()
+    # 1. OVERWRITE EXISTING FILES
+    cmd.append('-O')
+    cmd.extend(self._options)
 
-      # 3. add operators
-      #   collect operator parameters and pad them to the operator name
-      operator = ['-'+method_name]
-      if args.__len__() != 0:
-        for arg in args:
-          operator.append(arg.__str__())
-      operatorCall = ','.join(operator)
-      cmd.append(operatorCall)
+    # 2. set the options
+    # switch to netcdf output in case of numpy/xarray usage
+    if (   None != kwargs.get('returnArray')
+        or None != kwargs.get('returnMaArray')
+        or None != kwargs.get('returnXArray')
+        or None != kwargs.get('returnXDataset')
+        or None != kwargs.get('returnCdf')):
+      cmd.append('-f nc')
+    if 'options' in kwargs:
+      cmd += kwargs['options'].split()
 
-      # 4. input files or other operators
-      if 'input' in kwargs:
-        if isinstance(kwargs["input"], six.string_types):
+
+    # 3. add operators
+    #   collect operator parameters and pad them to the operator name
+    if len(args) != 0:
+      self._cmd[-1] += ',' + ','.join(map(str, args))
+    if self._cmd:
+      cmd.extend(self._cmd)
+
+    # 4. input files or other operators
+    if 'input' in kwargs:
+      if isinstance(kwargs["input"], six.string_types):
+        cmd.append(kwargs["input"])
+      elif type(kwargs["input"]) == list:
+        cmd.append(' '.join(kwargs["input"]))
+      elif self.hasXarray:
+        import xarray #<<-- python2 workaround
+        if (type(kwargs["input"]) == xarray.core.dataset.Dataset):
+          # create a temp nc file from input data
+          tmpfile = self.tempStore.newFile()
+          kwargs["input"].to_netcdf(tmpfile)
+          kwargs["input"] = tmpfile
+
           cmd.append(kwargs["input"])
-        elif type(kwargs["input"]) == list:
-          cmd.append(' '.join(kwargs["input"]))
-        elif self.hasXarray:
-          import xarray #<<-- python2 workaround
-          if (type(kwargs["input"]) == xarray.core.dataset.Dataset):
-            # create a temp nc file from input data
-            tmpfile = self.tempStore.newFile()
-            kwargs["input"].to_netcdf(tmpfile)
-            kwargs["input"] = tmpfile
+      else:
+        # we assume it's either a list, a tuple or any iterable.
+        cmd.append(kwargs["input"])
 
-            cmd.append(kwargs["input"])
-        else:
-          # we assume it's either a list, a tuple or any iterable.
-          cmd.append(kwargs["input"])
+    # 5. handle rewrite of existing output files
+    if not kwargs.__contains__("force"):
+      kwargs["force"] = self.forceOutput
 
-      # 5. handle rewrite of existing output files
-      if not kwargs.__contains__("force"):
-        kwargs["force"] = self.forceOutput
+    # 6. handle environment setup per call
+    envOfCall = {}
+    if kwargs.__contains__("env"):
+      for k, v in kwargs["env"].items():
+        envOfCall[k] = v
 
-      # 6. handle environment setup per call
-      envOfCall = {}
-      if kwargs.__contains__("env"):
-        for k, v in kwargs["env"].items():
-          envOfCall[k] = v
+    # 7. output handling: use given outputs or create temporary files
+    outputs = []
 
-      # 7. output handling: use given outputs or create temporary files
-      outputs = []
+    # collect the given output
+    if None != kwargs.get("output"):
+      outputs.append(kwargs["output"])
 
-      # collect the given output
-      if None != kwargs.get("output"):
-        outputs.append(kwargs["output"])
+    if not kwargs.get('compute') and not 'input' in kwargs:
+      return self
+    elif not kwargs.get('keep', True):
+      self._cmd.clear()
 
-      if operatorPrintsOut:
-        retvals = self.__call(cmd, envOfCall)
-        if (not self.__hasError(method_name, cmd, retvals)):
-          r = list(map(strip, retvals["stdout"].split(os.linesep)))
-          if "autoSplit" in kwargs:
-            splitString = kwargs["autoSplit"]
-            _output = [x.split(splitString) for x in r[:len(r) - 1]]
-            if (1 == len(_output)):
-                return _output[0]
-            else:
-                return _output
+    if operatorPrintsOut:
+      retvals = self.__call(cmd, envOfCall)
+      if (not self.__hasError(method_name, cmd, retvals)):
+        r = list(map(strip, retvals["stdout"].split(os.linesep)))
+        if "autoSplit" in kwargs:
+          splitString = kwargs["autoSplit"]
+          _output = [x.split(splitString) for x in r[:len(r) - 1]]
+          if (1 == len(_output)):
+              return _output[0]
           else:
-           return r[:len(r) - 1]
+              return _output
         else:
+         return r[:len(r) - 1]
+      else:
+        if self.returnNoneOnError:
+          return None
+        else:
+          raise CDOException(**retvals)
+    else:
+      if kwargs["force"] or \
+         (kwargs.__contains__("output") and not os.path.isfile(kwargs["output"])):
+        if not kwargs.__contains__("output") or None == kwargs["output"]:
+          for i in range(0, self.operators[method_name]):
+            outputs.append(self.tempStore.newFile())
+
+        cmd.append(' '.join(outputs))
+
+        retvals = self.__call(cmd, envOfCall)
+        if self.__hasError(method_name, cmd, retvals):
           if self.returnNoneOnError:
             return None
           else:
             raise CDOException(**retvals)
       else:
-        if kwargs["force"] or \
-           (kwargs.__contains__("output") and not os.path.isfile(kwargs["output"])):
-          if not kwargs.__contains__("output") or None == kwargs["output"]:
-            for i in range(0, self.operators[method_name]):
-              outputs.append(self.tempStore.newFile())
+        if self.debug:
+          print(("Use existing file'" + kwargs["output"] + "'"))
 
-          cmd.append(' '.join(outputs))
+    # defaults for file handles as return values
+    if not kwargs.__contains__("returnCdf"):
+      kwargs["returnCdf"] = False
+    if not kwargs.__contains__("returnXDataset"):
+      kwargs["returnXDataset"] = False
 
-          retvals = self.__call(cmd, envOfCall)
-          if self.__hasError(method_name, cmd, retvals):
-            if self.returnNoneOnError:
-              return None
-            else:
-              raise CDOException(**retvals)
-        else:
-          if self.debug:
-            print(("Use existing file'" + kwargs["output"] + "'"))
+    # return data arrays
+    if None != kwargs.get("returnArray"):
+      return self.readArray(outputs[0], kwargs["returnArray"])
+    elif None != kwargs.get("returnMaArray"):
+      return self.readMaArray(outputs[0], kwargs["returnMaArray"])
+    elif None != kwargs.get("returnXArray"):
+      return self.readXArray(outputs[0], kwargs.get("returnXArray"))
 
-      # defaults for file handles as return values
-      if not kwargs.__contains__("returnCdf"):
-        kwargs["returnCdf"] = False
-      if not kwargs.__contains__("returnXDataset"):
-        kwargs["returnXDataset"] = False
-
-      # return data arrays
-      if None != kwargs.get("returnArray"):
-        return self.readArray(outputs[0], kwargs["returnArray"])
-      elif None != kwargs.get("returnMaArray"):
-        return self.readMaArray(outputs[0], kwargs["returnMaArray"])
-      elif None != kwargs.get("returnXArray"):
-        return self.readXArray(outputs[0], kwargs.get("returnXArray"))
-
-      # return files handles (or lists of them)
-      elif kwargs["returnCdf"]:
-        if 1 == len(outputs):
-          return self.readCdf(outputs[0])
-        else:
-          return [self.readCdf(file) for file in outputs]
-      elif kwargs["returnXDataset"]:
-        if 1 == len(outputs):
-          return self.readXDataset(outputs[0])
-        else:
-          return [self.readXDataset(file) for file in outputs]
-
-      # handle split-operator outputs
-      elif ('split' == method_name[0:5]):
-        return glob.glob(kwargs["output"] + '*')
-
-      # default: return filename (given or tempfile)
+    # return files handles (or lists of them)
+    elif kwargs["returnCdf"]:
+      if 1 == len(outputs):
+        return self.readCdf(outputs[0])
       else:
-        if (1 == len(outputs)):
-          return outputs[0]
-        else:
-          return outputs
+        return [self.readCdf(file) for file in outputs]
+    elif kwargs["returnXDataset"]:
+      if 1 == len(outputs):
+        return self.readXDataset(outputs[0])
+      else:
+        return [self.readXDataset(file) for file in outputs]
+
+    # handle split-operator outputs
+    elif ('split' == method_name[0:5]):
+      return glob.glob(kwargs["output"] + '*')
+
+    # default: return filename (given or tempfile)
+    else:
+      if (1 == len(outputs)):
+        return outputs[0]
+      else:
+        return outputs
+
+  def __getattr__(self, method_name):  # main method-call handling for Cdo-objects {{{
 
     if ((method_name in self.__dict__) or (method_name in list(self.operators.keys()))):
       if self.debug:
         print(("Found method:" + method_name))
 
       # cache the method for later
-      setattr(self.__class__, method_name, get)
-      return get.__get__(self)
+      class Operator(self.__class__):
+
+        __doc__ = operator_doc(method_name, self.CDO)
+
+        name = method_name
+
+      setattr(self.__class__, method_name, Operator())
+      return getattr(self, method_name)
     else:
       # given method might match part of know operators: autocompletion
       if (len(list(filter(lambda x: re.search(method_name, x), list(self.operators.keys())))) == 0):
@@ -605,8 +661,13 @@ class Cdo(object):
 
     return delta_levels
 
-  def readCdf(self, iFile):
+  def read(self, output=None):
+    return self(output=output, compute=True)
+
+  def readCdf(self, iFile=None):
     """Return a cdf handle created by the available cdf library"""
+    if iFile is None:
+      iFile = self.read()
     if self.hasNetcdf:
       fileObj = self.cdf(iFile, mode='r')
       return fileObj
@@ -614,19 +675,27 @@ class Cdo(object):
       print("Could not import data from file '%s' (python-netCDF4)" % iFile)
       six.raise_from(ImportError,None)
 
-  def readArray(self, iFile, varname):
+  def readArray(self, iFile=None, varname=None):
     """Direcly return a numpy array for a given variable name"""
+    if iFile is None:
+      iFile = self.read()
+    if varname is None:
+      raise ValueError("A varname needs to be specified!")
     filehandle = self.readCdf(iFile)
     try:
       # return the data array for given variable name
       return filehandle.variables[varname][:].copy()
-    except: 
+    except:
       print("Cannot find variable '%s'" % varname)
       six.raise_from(LookupError,None)
 
 
-  def readMaArray(self, iFile, varname):# {{{
+  def readMaArray(self, iFile=None, varname=None):# {{{
     """Create a masked array based on cdf's FillValue"""
+    if iFile is None:
+      iFile = self.read()
+    if varname is None:
+      raise ValueError("A varname needs to be specified!")
     fileObj = self.readCdf(iFile)
 
     if not varname in fileObj.variables:
@@ -644,7 +713,11 @@ class Cdo(object):
 
     return retval# }}}
 
-  def readXArray(self, ifile, varname):
+  def readXArray(self, ifile=None, varname=None):
+    if ifile is None:
+      ifile = self.read()
+    if varname is None:
+      raise ValueError("A varname needs to be specified!")
     if not self.hasXarray:
       print("Could not load XArray")
       six.raise_from(ImportError,None)
@@ -656,11 +729,13 @@ class Cdo(object):
       print("Cannot find variable '%s'" % varname)
       six.raise_from(LookupError,None)
 
-  def readXDataset(self, ifile):
+  def readXDataset(self, ifile=None):
+    if ifile is None:
+      ifile = self.read()
     if not self.hasXarray:
       print("Could not load XArray")
       six.raise_from(ImportError,None)
-    
+
     return self.xa_open(ifile)
 
   # internal helper methods:
@@ -680,18 +755,26 @@ class CdoTempfileStore(object):
 
   __tempfiles = []
 
+  __tempdirs = []
+
   def __init__(self, dir):
     self.persistent_tempfile = False
     self.fileTag = 'cdoPy'
     self.dir = dir
     if not os.path.isdir(dir):
       os.makedirs(dir)
+    self.__tempdirs.append(dir)
 
   def __del__(self):
     # remove temporary files
-    for filename in self.__class__.__tempfiles:
-      if os.path.isfile(filename):
-        os.remove(filename)
+    try:
+      self.__tempdirs.remove(self.dir)
+    except ValueError:
+      pass
+    if self.dir not in self.__tempdirs:
+      for filename in self.__class__.__tempfiles:
+        if os.path.isfile(filename):
+          os.remove(filename)
 
   def cleanTempDir(self):
     leftOvers = [os.path.join(self.dir, f) for f in os.listdir(self.dir)]

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -359,6 +359,7 @@ class Cdo(object):
     return self
 
   def __call__(self, *args, **kwargs):
+    user_kwargs = kwargs.copy()
     try:
       method_name = self._cmd[0][1:].split(',')[0]
     except IndexError:
@@ -430,7 +431,7 @@ class Cdo(object):
     if None != kwargs.get("output"):
       outputs.append(kwargs["output"])
 
-    if not kwargs.get('compute') and not 'input' in kwargs:
+    if not user_kwargs or not kwargs.get('compute', True):
       return self
     elif not kwargs.get('keep', True):
       self._cmd.clear()
@@ -662,7 +663,10 @@ class Cdo(object):
     return delta_levels
 
   def read(self, output=None):
-    return self(output=output, compute=True)
+    if output:
+      return self(output=output, compute=True)
+    else:
+      return self(compute=True)
 
   def readCdf(self, iFile=None):
     """Return a cdf handle created by the available cdf library"""

--- a/python/test/test_cdo.py
+++ b/python/test/test_cdo.py
@@ -450,7 +450,7 @@ class CdoTest(unittest2.TestCase):
         cdo.__print__('test_errorException')
         self.assertFalse(hasattr(cdo, 'nonExistingMethod'))
         self.assertFalse(not 'max' in cdo.operators)
-        self.failUnlessRaises(CDOException, cdo.max)
+        self.failUnlessRaises(CDOException, cdo.max.read)
         try:
             cdo.max()
         except CDOException as e:
@@ -606,10 +606,11 @@ class CdoTest(unittest2.TestCase):
           print(cdo)
         if cdo.hasNetcdf:
           bathy = cdo.setrtomiss(0,10000,
-                                 input = cdo.topo('r100x100'),returnMaArray='var1')
+                                 input = cdo.topo('r100x100').read(),
+                                 returnMaArray='var1')
           plot(bathy)
           oro = cdo.setrtomiss(-10000,0,
-                               input = cdo.topo(),returnMaArray='var1')
+                               input = cdo.topo().read(),returnMaArray='var1')
           plot(oro)
           random = cdo.setname('test_maArray',
                                input = "-setrtomiss,0.4,0.8 -random,r180x90 ",

--- a/python/test/test_cdo.py
+++ b/python/test/test_cdo.py
@@ -175,13 +175,13 @@ class CdoTest(unittest2.TestCase):
 
     def test_pychain(self):
         cdo = Cdo()
-        ofile = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").read()
+        ofile = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").run()
         self.assertEqual(["veloc"],cdo.showname(input = ofile))
 
     def test_pychain2(self):
         # compare the two different ways
         cdo = Cdo()
-        ofile1 = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").read()
+        ofile1 = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").run()
         cdo = Cdo()
         ofile2 = cdo.setname("veloc", input=" -copy -random,r1x1",options = "-f nc")
         diff = cdo.diff(input=[ofile1, ofile2])
@@ -606,11 +606,11 @@ class CdoTest(unittest2.TestCase):
           print(cdo)
         if cdo.hasNetcdf:
           bathy = cdo.setrtomiss(0,10000,
-                                 input = cdo.topo('r100x100').read(),
+                                 input = cdo.topo('r100x100').run(),
                                  returnMaArray='var1')
           plot(bathy)
           oro = cdo.setrtomiss(-10000,0,
-                               input = cdo.topo().read(),returnMaArray='var1')
+                               input = cdo.topo().run(),returnMaArray='var1')
           plot(oro)
           random = cdo.setname('test_maArray',
                                input = "-setrtomiss,0.4,0.8 -random,r180x90 ",

--- a/python/test/test_cdo.py
+++ b/python/test/test_cdo.py
@@ -173,6 +173,20 @@ class CdoTest(unittest2.TestCase):
         ofile = cdo.setname("veloc", input=" -copy -random,r1x1",options = "-f nc")
         self.assertEqual(["veloc"],cdo.showname(input = ofile))
 
+    def test_pychain(self):
+        cdo = Cdo()
+        ofile = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").read()
+        self.assertEqual(["veloc"],cdo.showname(input = ofile))
+
+    def test_pychain2(self):
+        # compare the two different ways
+        cdo = Cdo()
+        ofile1 = cdo.setname("veloc").copy.random("r1x1").add_option("-f nc").read()
+        cdo = Cdo()
+        ofile2 = cdo.setname("veloc", input=" -copy -random,r1x1",options = "-f nc")
+        diff = cdo.diff(input=[ofile1, ofile2])
+        self.assertFalse(diff, msg=diff)
+
     def test_diff(self):
         cdo = Cdo()
         cdo.debug = DEBUG


### PR DESCRIPTION
Hey @Try2Code! I was always a bit disappointed by how the cdo-bindings handle the chaining of operators. This chain is one of the greatest features of CDOs and the current implementation

```python
cdo.operatort(input='-op1 -op2 infile1 infile2')
```

is not very pythonic, in that sense, that it requires long string manipulations. But CDOs are written in an object-oriented manner and so should the python bindings! 

With this PR, I propose a new method (although backwards-compatibility of the API is assured!). Instead of chaining the operators as a string, you chain them as python objects:

```python
cdo.operator.op1.op2.infile(infile1, infile2).read()
```

This has multiple advantage compared the the old approach:

1. it much better mimics the OO-shell approach of CDOs
2. it makes your operators reusable

  ```python
  chain = cdo.output.fldmean
  v1 = chain.selname('t2m').infile('demo.nc').read()
  v2 = chain.selname('u').infile('demo.nc').read()
  ```
3. it makes the help better accessible:
  ```python
  help(cdo.output.fldmean) # prints the help of fldmeann
  ```

You can play around a bit interactively with [this gist](https://gist.github.com/Chilipp/5c3f2e5151ce047bac3a0f33c1446304) on binder by clicking on the following button: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gist/Chilipp/5c3f2e5151ce047bac3a0f33c1446304/master)

## Changes to the code
As I said previously, the old API is still preserved, so it is backwards compatible. However, I changed some of the internals:

1. The `Cdo` class can now be used as a descriptor (i.e. I implemented a `Cdo.__get__` method). Accessing such a descriptor returns a new instance of the `Cdo` class with the same properties but an enhanced cdo command (`cmd`)
2. instances of the `Cdo` are callable (i.e. they have a `__call__` method). This method essentially has the same content as methods that have been formerly defined in the `Cdo.__getattr__` method
3. The `__getattr__` method now does not add new methods to the `Cdo` class anymore. Instead it subclases the `Cdo` class and adds the new instance as an attributes to the `Cdo` class. With the two previous implementations (the `__get__` and `__call__` methods), they API is still the same. Only the attribute types changed:
  
  - previous:
    ```python
    type(cdo.output)
    # method
    ```
  - new:
    ```python
    type(cdo.output)
    # cdo.Cdo.__getattr__.<locals>.Operator
    isinstance(cdo.output, Cdo)
    # True
    ```
4. I implemented an `infile` method and a `read` method. Note that
  ```python
  cdo.fldmean.infile('demo.nc').read('output.nc')
  ```
  gives the same result as
  ```python
  cdo.output(input='demo.nc', output='output.nc')
  ```
5. the `ifile` for the `readXArray`, etc. methods is now optional. If not provided, the `read` method is called and the data is calculated
6. I also added two more tests: the `test_pychain` and `test_pychain2` methods.