### PR TITLE
updated wrong method in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The default is false of cause.
 ```
 ```python
     cdo.infov(input=ifile)         #python
-    cdo.showlevels(input=ifile)
+    cdo.showlevel(input=ifile)
 ```
 
 #### Operators with user defined regular output files


### PR DESCRIPTION
should be `cdo.showlevel` instead of `cdo.showlevels`. May be the case for ruby aswell.