### PR TITLE
Fix signal interruption issues and related minor changes

### DIFF
--- a/python/cdo.py
+++ b/python/cdo.py
@@ -562,9 +562,11 @@ class Cdo(object):
         else:
             # given method might match part of know operators: autocompletion
             func = lambda x: re.search(method_name, x)
-            if (len(list(filter(func, list(self.operators.keys())))) == 0):
-                # If the method isn't in our dictionary, act normal.
-                raise AttributeError("Unknown method '" + method_name + "'!")
+            options = list(filter(func, self.operators.keys()))
+            message = "Unknown method '" + method_name + "'!"
+            if 0 != len(options):
+                message += " Did you mean: " + ", ".join(options) + "?"
+            raise AttributeError(message)
     # }}}
 
     def getSupportedLibs(self, force=False):

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -781,7 +781,6 @@ class CdoTempfileStore(object):
         self.dir = dir
         if not os.path.isdir(dir):
             os.makedirs(dir)
-        self.__tempdirs.append(dir)
         # handling different exits from interactive sessions
         # python3 has threading.main_thread(), but python2 doesn't
         if sys.version_info[0] == 2 \

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -180,9 +180,9 @@ class Cdo(object):
             sigint_default = signal.getsignal(signal.SIGINT)
             sigterm_default = signal.getsignal(signal.SIGTERM)
             sigsegv_default = signal.getsignal(signal.SIGSEGV)
-            sigint = functools.partial(self.__catch__, default=sigint_default)
-            sigterm = functools.partial(self.__catch__, default=sigterm_default)
-            sigsegv = functools.partial(self.__catch__, default=sigsegv_default)
+            sigint = functools.partial(self.__catch__, throw=sigint_default)
+            sigterm = functools.partial(self.__catch__, throw=sigterm_default)
+            sigsegv = functools.partial(self.__catch__, throw=sigsegv_default)
             signal.signal(signal.SIGINT,  sigint)
             signal.signal(signal.SIGTERM, sigterm)
             signal.signal(signal.SIGSEGV, sigsegv)
@@ -658,10 +658,10 @@ class Cdo(object):
         self.tempStore.cleanTempDir()
 
     # if a termination signal could be caught, remove tempfile
-    def __catch__(self, signum, frame, default=None, **kwargs):
+    def __catch__(self, signum, frame, throw=None, **kwargs):
         self.tempStore.__del__()
-        if callable(default):
-            default(signum, frame, **kwargs)
+        if callable(throw):
+            throw(signum, frame, **kwargs)
         else:
             print("caught signal", self, signum, frame)
 

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -658,10 +658,10 @@ class Cdo(object):
         self.tempStore.cleanTempDir()
 
     # if a termination signal could be caught, remove tempfile
-    def __catch__(self, signum, frame, default=None):
+    def __catch__(self, signum, frame, default=None, **kwargs):
         self.tempStore.__del__()
         if callable(default):
-            default()
+            default(signum, frame, **kwargs)
         else:
             print("caught signal", self, signum, frame)
 

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -201,7 +201,7 @@ class Cdo(object):
         # called with 'cdo.for()' because 'for' is a keyword in python. 'for' is
         # renamed to 'seq' in 1.9.7.
         # This workaround translates all calls of 'seq' into for in case of
-        # versions prior tp 1.9.7
+        # versions prior to 1.9.7
         if name in self.AliasOperators.keys() and \
                 (parse_version(getCdoVersion(self.CDO)) < parse_version('1.9.7')):
             name = self.AliasOperators[name]
@@ -324,9 +324,9 @@ class Cdo(object):
 
         if self.debug:  # debug printing {{{
             print('# DEBUG - start =============================================================')
-#     if {} != env:
-#       for k,v in list(env.items()):
-#         print("ENV: " + k + " = " + v)
+            # if {} != env:
+            #     for k,v in list(env.items()):
+            #         print("ENV: " + k + " = " + v)
             print('CALL  :' + ' '.join(cmd))
             print('STDOUT:')
             if (0 != len(stdout.strip())):
@@ -551,7 +551,11 @@ class Cdo(object):
 
             # cache the method for later
             class Operator(self.__class__):
-                name = __name__ = method_name
+                name = method_name
+                __name__ = method_name
+                __qualname__ = getattr(  # __qualname__ is available in python 3.3+
+                    self.__class__, '__qualname__', self.__class__.__name__
+                ) + '.' + method_name
 
                 def __init__(self, *args, **kwargs):
                     super().__init__(*args, **kwargs)
@@ -563,7 +567,7 @@ class Cdo(object):
             # given method might match part of know operators: autocompletion
             func = lambda x: re.search(method_name, x)
             options = list(filter(func, self.operators.keys()))
-            message = "Unknown method '" + method_name + "'!"
+            message = "Unknown operator '" + method_name + "'!"
             if 0 != len(options):
                 message += " Did you mean: " + ", ".join(options) + "?"
             raise AttributeError(message)

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -572,12 +572,12 @@ class Cdo(object):
     def getSupportedLibs(self, force=False):
         proc = subprocess.Popen(self.CDO + ' -V',
                                 shell=True,
-                                stderr=subprocess.PIPE,
-                                stdout=subprocess.PIPE)
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
         retvals = proc.communicate()
-
         withs = list(re.findall('(with|Features): (.*)',
-                                retvals[1].decode("utf-8"))[0])[1].split(' ')
+                                retvals[0].decode("utf-8"))[0])[1].split(' ')
+
         # do an additional split if the entry has a /
         # and collect everything into a flatt list
         withs = list(map(lambda x: x.split('/') if re.search(r'\/', x) else x, withs))
@@ -591,7 +591,7 @@ class Cdo(object):
         withs = allWiths
 
         libs = re.findall(r'(\w+) library version : (\d+\.\S+) ',
-                          retvals[1].decode("utf-8"))
+                          retvals[0].decode("utf-8"))
         libraries = dict({})
         for w in withs:
             libraries[w.lower()] = True
@@ -619,12 +619,9 @@ class Cdo(object):
     def hasCdo(self, path=None):
         if path is None:
             path = self.CDO
-
-        cmd = [path, " -V", '>/dev/null 2>&1']
-
+        cmd = [path, ' -V', '>/dev/null 2>&1']
         executable = (0 == self.__call(cmd)["returncode"])
         fullpath = (os.path.isfile(path) and os.access(path, os.X_OK))
-
         return (executable or fullpath)
 
     # selfcheck for the current CDO binary

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -776,7 +776,6 @@ class Cdo(object):
 class CdoTempfileStore(object):
 
     __tempfiles = []
-    __tempdirs = []
 
     def __init__(self, dir):
         self.persistent_tempfile = False
@@ -797,14 +796,9 @@ class CdoTempfileStore(object):
 
     def __del__(self):
         # remove temporary files
-        try:
-            self.__tempdirs.remove(self.dir)
-        except ValueError:
-            pass
-        if self.dir not in self.__tempdirs:
-            for filename in self.__class__.__tempfiles:
-                if os.path.isfile(filename):
-                    os.remove(filename)
+        for filename in self.__class__.__tempfiles:
+            if os.path.isfile(filename):
+                os.remove(filename)
 
     def __catch__(self, signum, frame, throw=None, **kwargs):
         # if a termination signal could be caught, remove tempfile

--- a/python/cdo.py
+++ b/python/cdo.py
@@ -152,26 +152,25 @@ class Cdo(object):
         self._cmd = cmd
         self._options = options
 
-        self.operators         = self.__getOperators()
-        self.noOutputOperators = [
-            op for op in self.operators.keys() if 0 == self.operators[op]]
+        self.operators = self.__getOperators()
+        self.noOutputOperators = [op for op, num in self.operators.items() if 0 == num]
         self.returnNoneOnError = returnNoneOnError
-        self.tempStore         = tempStore or CdoTempfileStore(dir=tempdir)
-        self.forceOutput       = forceOutput
-        self.env               = env
-        self.debug             = True if 'DEBUG' in os.environ else debug
-        self.libs              = self.getSupportedLibs()
+        self.tempStore = tempStore or CdoTempfileStore(dir=tempdir)
+        self.forceOutput = forceOutput
+        self.env = env
+        self.debug = True if 'DEBUG' in os.environ else debug
+        self.libs = self.getSupportedLibs()
 
         # optional IO libraries for additional return types {{{
-        self.hasNetcdf         = False
-        self.hasXarray         = False
-        self.cdf               = None
-        self.xa_open           = None
+        self.hasNetcdf = False
+        self.hasXarray = False
+        self.cdf = None
+        self.xa_open = None
         self.__loadOptionalLibs()
 
         self.logging = logging  # internal logging {{{
         self.logFile = logFile
-        if (self.logging):
+        if self.logging:
             self.logger = setupLogging(self.logFile)  # }}}
 
     def __get__(self, instance, owner):
@@ -183,8 +182,8 @@ class Cdo(object):
         # renamed to 'seq' in 1.9.7.
         # This workaround translates all calls of 'seq' into for in case of
         # versions prior to 1.9.7
-        if name in self.AliasOperators.keys() and \
-                (parse_version(getCdoVersion(self.CDO)) < parse_version('1.9.7')):
+        if name in self.AliasOperators and (
+                parse_version(getCdoVersion(self.CDO)) < parse_version('1.9.7')):
             name = self.AliasOperators[name]
         return self.__class__(
             instance.CDO,
@@ -201,9 +200,9 @@ class Cdo(object):
 
     # from 1.9.6 onwards CDO returns 1 of diff* finds a difference
     def __exit_success(self, operatorName):
-        if (parse_version(getCdoVersion(self.CDO)) < parse_version('1.9.6')):
+        if parse_version(getCdoVersion(self.CDO)) < parse_version('1.9.6'):
             return 0
-        if ('diff' != operatorName[0:4]):
+        if 'diff' != operatorName[0:4]:
             return 0
         return 1
 
@@ -213,15 +212,15 @@ class Cdo(object):
         operators = {}
 
         version = parse_version(getCdoVersion(self.CDO))
-        if (version < parse_version('1.7.2')):
+        if version < parse_version('1.7.2'):
             proc = subprocess.Popen(
                 [self.CDO, '-h'], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
-            ret  = proc.communicate()
-            l    = ret[1].decode("utf-8").find("Operators:")
-            ops  = ret[1].decode("utf-8")[l:-1].split(os.linesep)[1:-1]
+            ret = proc.communicate()
+            l = ret[1].decode("utf-8").find("Operators:")
+            ops = ret[1].decode("utf-8")[l:-1].split(os.linesep)[1:-1]
             endI = ops.index('')
-            s    = ' '.join(ops[:endI]).strip()
-            s    = re.sub(r"\s+", " ", s)
+            s = ' '.join(ops[:endI]).strip()
+            s = re.sub(r"\s+", " ", s)
 
             for op in list(set(s.split(" "))):
                 operators[op] = 1
@@ -232,7 +231,7 @@ class Cdo(object):
                 if op in self.MoreOutputOperators:
                     operators[op] = -1
 
-        elif (version < parse_version('1.8.0') or parse_version('1.9.0') == version):
+        elif version < parse_version('1.8.0') or parse_version('1.9.0') == version:
             proc = subprocess.Popen([self.CDO, '--operators'],
                                     stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             ret = proc.communicate()
@@ -248,7 +247,7 @@ class Cdo(object):
                 if op in self.MoreOutputOperators:
                     operators[op] = -1
 
-        elif (version < parse_version('1.9.3')):
+        elif version < parse_version('1.9.3'):
             proc = subprocess.Popen([self.CDO, '--operators'],
                                     stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             ret = proc.communicate()
@@ -278,8 +277,8 @@ class Cdo(object):
             ret = proc.communicate()
             ops = list(map(lambda x: x.split(' ')[0], ret[0].decode(
                 "utf-8")[0:-1].split(os.linesep)))
-            ios = list(map(lambda x: x.split(' ')
-                       [-1], ret[0].decode("utf-8")[0:-1].split(os.linesep)))
+            ios = list(map(lambda x: x.split(' ')[-1], ret[0].decode(
+                "utf-8")[0:-1].split(os.linesep)))
 
             for i, op in enumerate(ops):
                 operators[op] = int(ios[i][1:len(ios[i]) - 1].split('|')[1])
@@ -311,10 +310,10 @@ class Cdo(object):
             #         print("ENV: " + k + " = " + v)
             print('CALL  :' + ' '.join(cmd))
             print('STDOUT:')
-            if (0 != len(stdout.strip())):
+            if 0 != len(stdout.strip()):
                 print(stdout)
             print('STDERR:')
-            if (0 != len(stderr.strip())):
+            if 0 != len(stderr.strip()):
                 print(stderr)
             # }}}
             print('# DEBUG - end ===============================================================')
@@ -323,9 +322,9 @@ class Cdo(object):
 
     # error handling for CDO calls
     def __hasError(self, method_name, cmd, retvals):  # {{{
-        if (self.debug):
+        if self.debug:
             print("RETURNCODE:" + retvals["returncode"].__str__())
-        if (self.__exit_success(method_name) < retvals["returncode"]):
+        if self.__exit_success(method_name) < retvals["returncode"]:
             print("Error in calling operator " + method_name + " with:")
             print(">>> " + ' '.join(cmd) + "<<<")
             print('STDOUT:' + retvals["stdout"])
@@ -349,10 +348,10 @@ class Cdo(object):
 
         try:
             from netCDF4 import Dataset as cdf
-            self.cdf       = cdf
-            self.hasNetcdf = True
             import numpy as np
-            self.np        = np
+            self.hasNetcdf = True
+            self.cdf = cdf
+            self.np = np
         except Exception:
             print("-->> Could not load netCDF4! <<--")  # }}}
 
@@ -362,7 +361,7 @@ class Cdo(object):
                 self._cmd.append(infile)
             elif self.hasXarray:
                 import xarray  # <<-- python2 workaround
-                if (type(infile) == xarray.core.dataset.Dataset):
+                if type(infile) == xarray.core.dataset.Dataset:
                     # create a temp nc file from input data
                     tmpfile = self.tempStore.newFile()
                     infile.to_netcdf(tmpfile)
@@ -417,7 +416,7 @@ class Cdo(object):
                 cmd.append(' '.join(kwargs["input"]))
             elif self.hasXarray:
                 import xarray  # <<-- python2 workaround
-                if (type(kwargs["input"]) == xarray.core.dataset.Dataset):
+                if type(kwargs["input"]) == xarray.core.dataset.Dataset:
                     # create a temp nc file from input data
                     tmpfile = self.tempStore.newFile()
                     kwargs["input"].to_netcdf(tmpfile)
@@ -452,12 +451,12 @@ class Cdo(object):
 
         if operatorPrintsOut:
             retvals = self.__call(cmd, envOfCall)
-            if (not self.__hasError(method_name, cmd, retvals)):
+            if not self.__hasError(method_name, cmd, retvals):
                 r = list(map(strip, retvals["stdout"].split(os.linesep)))
                 if "autoSplit" in kwargs:
                     splitString = kwargs["autoSplit"]
                     _output = [x.split(splitString) for x in r[:len(r) - 1]]
-                    if (1 == len(_output)):
+                    if 1 == len(_output):
                         return _output[0]
                     else:
                         return _output
@@ -514,22 +513,21 @@ class Cdo(object):
                 return [self.readXDataset(file) for file in outputs]
 
         # handle split-operator outputs
-        elif ('split' == method_name[0:5]):
+        elif 'split' == method_name[0:5]:
             return glob.glob(kwargs["output"] + '*')
 
         # default: return filename (given or tempfile)
         else:
-            if (1 == len(outputs)):
+            if 1 == len(outputs):
                 return outputs[0]
             else:
                 return outputs
 
     def __getattr__(self, method_name):  # main method-call handling for Cdo-objects {{{
-        if (method_name in self.__dict__) \
-           or (method_name in list(self.operators.keys())) \
-           or (method_name in self.AliasOperators):
+        if any(method_name in opts for opts in (
+               self.__dict__, self.operators, self.AliasOperators)):
             if self.debug:
-                print(("Found method:" + method_name))
+                print(("Found operator:" + method_name))
 
             # cache the method for later
             class Operator(self.__class__):
@@ -548,14 +546,14 @@ class Cdo(object):
         else:
             # given method might match part of know operators: autocompletion
             func = lambda x: re.search(method_name, x)
-            options = list(filter(func, self.operators.keys()))
+            options = list(filter(func, self.operators))
             message = "Unknown operator '" + method_name + "'!"
             if 0 != len(options):
                 message += " Did you mean: " + ", ".join(options) + "?"
             raise AttributeError(message)
     # }}}
 
-    def getSupportedLibs(self, force=False):
+    def getSupportedLibs(self):
         proc = subprocess.Popen(self.CDO + ' -V',
                                 shell=True,
                                 stdout=subprocess.PIPE,
@@ -628,7 +626,7 @@ class Cdo(object):
         return self.CDO
 
     def hasLib(self, lib):
-        return (lib in self.libs.keys())
+        return lib in self.libs
 
     def libsVersion(self, lib):
         if not self.hasLib(lib):
@@ -645,8 +643,8 @@ class Cdo(object):
 
     # make use of internal documentation structure of python
     def __dir__(self):
-        res = dir(type(self)) + list(self.__dict__.keys())
-        res.extend(list(self.operators.keys()))
+        res = dir(type(self)) + list(self.__dict__)
+        res.extend(list(self.operators))
         return res
 
     # ==================================================================


### PR DESCRIPTION
This seems to fix the issue where kill/interrupt signals outside of the cdo binding are suppressed mentioned in #26 and #43.

It also fixed a few quick-to-repair issues I came across during debugging:

*  I fixed a basic usage issue with recent versions of cdo (version 2.0.0+?). It seems some versions of cdo print the `-V` version info to stdout rather than stderr, which triggered an error when trying to initialize `Cdo()` because the binding was trying to parse the empty stderr output `proc.communicate()[1]`. I fixed this for all versions by always sending the output to stdout (using `stderr=subprocess.STDOUT` instead of `stderr=subprocess.PIPE`).
* I fixed #38 so that help info is shown (seems `__doc__` has to be overridden on the instance-level rather than the class-level). I also removed the unused (outdated?) `auto_doc` function and added `__name__ = method_name` so that the help prompt for e.g. `help(cdo.merge)` shows `merge(...)` rather than `<cdo.Cdo.__getattr__.<locals>.Operator object>`.
* I fixed subcommand autocompletion, which wasn't working before. Now when I type `cdo.mer`, rather than nothing happening, the error message is `AttributeError: Unknown operator 'mer'! Did you mean: meravg, merge, mergegrid, mergetime, merkurt, mermax, mermean, mermedian, mermin, merpctl, merrange, merskew, merstd, merstd1, mersum, mervar, mervar1?`.

Here's a basic example, hitting Ctrl+C after a couple seconds:

```python
In [1]: import time
   ...: from cdo import Cdo
   ...:
   ...: #cdo = Cdo()
   ...: while True:
   ...:     print("hi")
   ...:     time.sleep(1)
hi
hi
^C---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Input In [1], in <module>
      5 while True:
      6     print("hi")
----> 7     time.sleep(1)

KeyboardInterrupt:
```

Here's after initializing the binding, before this PR:

```python
In [3]: import time
   ...: from cdo import Cdo
   ...:
   ...: cdo = Cdo()
   ...: while True:
   ...:     print("hi")
   ...:     time.sleep(1)
hi
^Ccaught signal <cdo.Cdo object at 0x10e6f88b0> 2 <frame at 0x7fcca6031670, file '<ipython-input-3-873ff4417816>', line 7, code <module>>
hi
^Ccaught signal <cdo.Cdo object at 0x10e6f88b0> 2 <frame at 0x7fcca6031670, file '<ipython-input-3-873ff4417816>', line 7, code <module>>
hi
^Ccaught signal <cdo.Cdo object at 0x10e6f88b0> 2 <frame at 0x7fcca6031670, file '<ipython-input-3-873ff4417816>', line 7, code <module>>
```

Here's after initializing the binding, after this PR:

```python
In [1]: import time
   ...: from cdo import Cdo
   ...: cdo = Cdo()
   ...: while True:
   ...:     print("hi")
   ...:     time.sleep(1)
hi
hi
^C---------------------------------------------------------------------------
KeyboardInterrupt                         Traceback (most recent call last)
Input In [1], in <module>
      4 while True:
      5     print("hi")
----> 6     time.sleep(1)

File ~/forks/cdo-bindings/python/cdo.py:664, in Cdo.__catch__(self, signum, frame, default)
    662 self.tempStore.__del__()
    663 if callable(default):
--> 664     default()
    665 else:
    666     print("caught signal", self, signum, frame)

KeyboardInterrupt:
```